### PR TITLE
Fix: Pass options to Template.fromDirectory() in initTemplateInstance() to enable offline mode (#734)

### DIFF
--- a/packages/cicero-server/app.js
+++ b/packages/cicero-server/app.js
@@ -168,9 +168,14 @@ app.post('/draft/:template', async function (req, httpResponse, next) {
  * @returns {object} The template instance object.
  */
 async function initTemplateInstance(req) {
-    const template = await Template.fromDirectory(`${process.env.CICERO_DIR}/${req.params.template}`);
+    let options = {};
+    if (Object.prototype.hasOwnProperty.call(req.body, 'options')) {
+        options = req.body.options;
+    }
+    const template = await Template.fromDirectory(`${process.env.CICERO_DIR}/${req.params.template}`, options);
     return new Clause(template);
 }
+
 
 const server = app.listen(app.get('port'), function () {
     console.log('Server listening on port: ', app.get('port'));


### PR DESCRIPTION
**Closes #734**
This pull request addresses the issue where cicero-server does not work offline because the options are not being passed to Template.fromDirectory() in the initTemplateInstance() function. This prevents the offline: true flag from being respected, which causes cicero-server to attempt to download external models even when offline.
<!--- Provide an overall summary of the pull request -->

**Changes**
1. Updated the initTemplateInstance() function to check for and pass options (including the offline flag) when calling Template.fromDirectory().
2. Ensured that the offline: true option is correctly used to prevent downloading external models when offline.

**Flags**
1. Ensure the server behaves as expected when in offline mode, respecting the offline: true flag.
2. Test thoroughly both in online and offline modes to confirm the issue is resolved and no external model downloads occur when offline.

**Related Issues**
Issue #734 (This is the issue this pull request resolves.)

Author Checklist
- [ ] DCO sign-off: Ensure you signed off on your commit using --signoff if not already done.
- [ ]  Unit/Integration tests: Check that the feature is covered by tests, or add tests for offline functionality if necessary.
- [ ]  Commit message format: Double-check that your commit messages adhere to the [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format).
- [ ]  Documentation: Make sure any changes to offline behavior are documented if needed.
- [ ]  Merging: Ensure you're merging into the correct branch (usually master or main).
